### PR TITLE
Added flags to $EXTRA_FLAGS in itch-run to make the client run in Wayland mode

### DIFF
--- a/io.itch.itch.yaml
+++ b/io.itch.itch.yaml
@@ -22,6 +22,8 @@ finish-args:
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.freedesktop.ScreenSaver
 
+  - --filesystem=xdg-data/icons:ro
+
   - --env=PATH=/app/bin:/usr/bin:/usr/lib/extensions/vulkan/gamescope/bin
   - --env=WINEPREFIX=/var/data/wine
   - --env=WINEDLLOVERRIDES=mscoree,mshtml='

--- a/io.itch.itch.yaml
+++ b/io.itch.itch.yaml
@@ -22,8 +22,6 @@ finish-args:
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.freedesktop.ScreenSaver
 
-  - --filesystem=xdg-data/icons:ro
-
   - --env=PATH=/app/bin:/usr/bin:/usr/lib/extensions/vulkan/gamescope/bin
   - --env=WINEPREFIX=/var/data/wine
   - --env=WINEDLLOVERRIDES=mscoree,mshtml='

--- a/itch-run
+++ b/itch-run
@@ -15,4 +15,5 @@ fi
 echo "Debug: Will run Itch with the following arguments: ${EXTRA_ARGS[@]}"
 echo "Debug: Additionally, user gave: $@"
 
+EXTRA_FLAGS+=("--enable-features=UseOzonePlatform,WaylandWindowDecorations" "--ozone-platform-hint=auto")
 zypak-wrapper /app/bin/itch $@ ${EXTRA_FLAGS[@]}


### PR DESCRIPTION
added 
`--enable-features=UseOzonePlatform,WaylandWindowDecorations` 
and 
`--ozone-platform-hint=auto`
to the `$EXTRA_FLAGS` in the default case in `itch-run` to make the client run in Wayland mode.

Also added
`- --filesystem=xdg-data/icons:ro` to the default permissions to ensure the mouse cursor theme stays available and in use in wayland mode. 