### PR TITLE
Added XCURSOR_PATH to io.itch.itch.yaml

### DIFF
--- a/io.itch.itch.yaml
+++ b/io.itch.itch.yaml
@@ -28,6 +28,7 @@ finish-args:
   - --env=WINEDLLPATH=/app/dlls/lib32:/app/dlls/lib:/app/lib32/wine/wined3d:/app/lib/wine/wined3d
   - --env=LD_LIBRARY_PATH=/app/lib:/app/lib32
   - --env=GST_PLUGIN_SYSTEM_PATH=/app/lib/gstreamer-1.0:/usr/lib/x86_64-linux-gnu/gstreamer-1.0:/app/lib32/gstreamer-1.0:/usr/lib/i386-linux-gnu/gstreamer-1.0
+  - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons
 
   - --persist=.wine
   - --persist=.wine64


### PR DESCRIPTION
added `XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons` to `io.itch.itch.yaml` to ensure availability of the mouse cursor in both wayland and xorg mode.

Further this ensure availability  irregardless of whether `xdg-data/icons` or `/usr/share/icons` is populated or both.

This solution is taken from https://github.com/flathub/io.github.spacingbat3.webcord and seems to be more standard conform to flatpak as it makes both `xdg-data/icons` and `/usr/share/icons` as well as `xdg-data/fonts` and `/usr/share/fonts` available inside the flatpak at `/run/host/user-share` and `/run/host/share` respectively. 

As such this solution also explains the problem the build bot had with `--filesystem=xdg-data/icons:ro` in https://github.com/flathub/io.itch.itch/commit/fe19b1493b2a23ee2be708354c178f4c39a10e11 given that the directory was made available by default already anyway by means of linking to `/run/host/user-share`

Finally: Explicitly pointing `XCURSOR_PATH` to those `/run/host` directories ensures availability of the cursor if xdg-icons is not populated and under wayland it seems the mouse cursor default paths seem to require this. On Xorg a test has shown this to not be the case