### PR TITLE
Add Permission to Enable Tray Icon

### DIFF
--- a/io.itch.itch.yaml
+++ b/io.itch.itch.yaml
@@ -22,6 +22,9 @@ finish-args:
   - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.freedesktop.ScreenSaver
 
+  # Needed for the tray icon to work properly
+  - --own-name=org.kde.*
+
   - --env=PATH=/app/bin:/usr/bin:/usr/lib/extensions/vulkan/gamescope/bin
   - --env=WINEPREFIX=/var/data/wine
   - --env=WINEDLLOVERRIDES=mscoree,mshtml='


### PR DESCRIPTION
This adds the `- --own-name=org.kde.*` permission to enable the tray icon functionality. The linter is probably not going to be happy with this, so an exception will probably have to be made, speaking of experience.

For that case, here's already preemptively the information for the Flathub team. This client still uses [Electron 22](https://github.com/itchio/itch/blob/master/package-lock.json#L98C1-L98C10), which has not yet implemented the functionality required to drop this permission. If that is unacceptable, I understand and will gladly close this, while keeping the workaround locally on my system.