### PR TITLE
Drop the EOL org.winehq.Wine.DLLs.dxvk Extension

### DIFF
--- a/io.itch.itch.yaml
+++ b/io.itch.itch.yaml
@@ -44,7 +44,6 @@ inherit-extensions:
   - org.freedesktop.Platform.ffmpeg_full.i386
   - org.winehq.Wine.gecko
   - org.winehq.Wine.mono
-  - org.winehq.Wine.DLLs
 
 add-extensions:
 


### PR DESCRIPTION
This extension has been dropped, as it has been broken for some time, according to https://github.com/flathub/org.winehq.Wine/issues/154.

This removes the warning when updating Flatpaks.