### PR TITLE
Update Itch to v26.15.0

### DIFF
--- a/io.itch.itch.metainfo.xml
+++ b/io.itch.itch.metainfo.xml
@@ -88,7 +88,7 @@
 		</screenshot>
 	</screenshots>
 	<releases>
-		<release version="v26.15.0" date="2026-07-07">
+		<release version="26.15.0" date="2026-07-07">
 			<url>https://github.com/itchio/itch/releases/tag/v26.15.0</url>
 			<description>
 				<p>This release adds a page for browsing and installing games from itch.io bundles you own, a platform filter on the collection, bundle, and library pages, accessibility improvements to the sort and filter dropdowns, and an Electron bump.</p>
@@ -121,7 +121,7 @@
 				</ul>
 			</description>
 		</release>
-		<release version="v26.13.0" date="2026-05-18">
+		<release version="26.13.0" date="2026-05-18">
 			<url>https://github.com/itchio/itch/releases/tag/v26.13.0</url>
 			<description>
 				<p>A follow-up to 26.12.0 with Upload page fixes and an Electron bump.</p>
@@ -141,7 +141,7 @@
 				</ul>
 			</description>
 		</release>
-		<release version="v26.12.0" date="2026-05-14">
+		<release version="26.12.0" date="2026-05-14">
 			<url>https://github.com/itchio/itch/releases/tag/v26.12.0</url>
 			<description>
 				<p>A small follow-up to 26.11.0 that opens the Upload page to all users and surfaces information about optimized patches.</p>
@@ -157,7 +157,7 @@
 				</ul>
 			</description>
 		</release>
-		<release version="v26.11.0" date="2026-05-12">
+		<release version="26.11.0" date="2026-05-12">
 			<url>https://github.com/itchio/itch/releases/tag/v26.11.0</url>
 			<description>
 				<p>Adds a UI for uploading builds to itch.io with butler without needing to drop down to the terminal, upgrades to Electron 41 and TypeScript 6, and includes accessibility, hotkey, and Linux autostart fixes.</p>
@@ -219,7 +219,7 @@
 				</ul>
 			</description>
 		</release>
-		<release version="v26.9.0" date="2026-02-21">
+		<release version="26.9.0" date="2026-02-21">
 			<description>
 				<p>This release upgrades Electron from 25 to 40, overhauls sandboxing across Linux,
 					macOS, and Windows, makes install planning non-blocking, and adds support for
@@ -356,11 +356,11 @@
 				</ul>
 			</description>
 		</release>
-		<release version="v26.6.0" date="2026-02-06">
+		<release version="26.6.0" date="2026-02-06">
 		</release>
-		<release version="v26.1.9" date="2024-06-06">
+		<release version="26.1.9" date="2024-06-06">
 		</release>
-		<release version="v25.5.1" date="2021-05-11">
+		<release version="25.5.1" date="2021-05-11">
       <url>https://github.com/itchio/itch/releases/tag/v25.5.1</url>
       <description>
         <ul>

--- a/io.itch.itch.metainfo.xml
+++ b/io.itch.itch.metainfo.xml
@@ -88,6 +88,39 @@
 		</screenshot>
 	</screenshots>
 	<releases>
+		<release version="v26.15.0" date="2026-07-07">
+			<url>https://github.com/itchio/itch/releases/tag/v26.15.0</url>
+			<description>
+				<p>This release adds a page for browsing and installing games from itch.io bundles you own, a platform filter on the collection, bundle, and library pages, accessibility improvements to the sort and filter dropdowns, and an Electron bump.</p>
+				<p><em>Bundles</em></p>
+				<ul>
+					<li>Bundles you own now show up in your Library, each with its own page listing every game in the bundle</li>
+					<li>The bundle page can be sorted, searched by title, and filtered by platform, classification, and installed status</li>
+					<li>Games can be installed directly from the bundle page</li>
+					<li>Requires a version of butler with bundle support</li>
+				</ul>
+				<p><em>Filtering</em></p>
+				<ul>
+					<li>Added a platform filter (Windows, macOS, Linux, Web) to the collection, bundle, and library pages</li>
+				</ul>
+				<p><em>Accessibility</em></p>
+				<ul>
+					<li>The sort and filter dropdowns are now keyboard and screen reader friendly, with combobox/listbox roles and arrow-key navigation</li>
+				</ul>
+				<p><em>Hotkeys</em></p>
+				<ul>
+					<li>Removed the <code>Ctrl+Alt+Backspace</code> shortcut that force-killed the last running game (#3453)</li>
+				</ul>
+				<p><em>Upload</em></p>
+				<ul>
+					<li>Fixed the file labels shown for builds that are still processing</li>
+				</ul>
+				<p><em>Electron</em></p>
+				<ul>
+					<li>Upgraded Electron from 42.1.0 to 43.0.0</li>
+				</ul>
+			</description>
+		</release>
 		<release version="v26.13.0" date="2026-05-18">
 			<url>https://github.com/itchio/itch/releases/tag/v26.13.0</url>
 			<description>

--- a/io.itch.itch.yaml
+++ b/io.itch.itch.yaml
@@ -122,8 +122,8 @@ modules:
       - type: archive
         strip-components: 0
         archive-type: zip
-        url: https://broth.itch.zone/itch/linux-amd64/26.13.0/archive/default
-        sha256: 0e11d8968c97dc71d500113e887b1b005edeca52e523d7c6c9473844d06d9aa1
+        url: https://broth.itch.zone/itch/linux-amd64/26.15.0/archive/default
+        sha256: c5bc21f9584bb7802d5875ca5244483dae5360efbc6e39677b0bf497d2df8b10
         x-checker-data:
           type: html
           url: https://broth.itch.zone/itch/linux-amd64/LATEST


### PR DESCRIPTION
I updated the package to the recently released v26.15.0, added the changelog, and used the opportunity to drop the `v` from the versioning in the releases, so automatic updates won't fail any more in the future. I tried to adjust the `x-checker-data` setup first, but there is no clean way to achieve this from what I can tell.